### PR TITLE
Allow using a function for user-provided cover.

### DIFF
--- a/src/components/cover.typ
+++ b/src/components/cover.typ
@@ -74,6 +74,10 @@
       ]
     ]
   }
+  else if type(cover) == function {
+      cover(title, subtitle, date, authors, volume, cfg)
+  }
+
   else if type(cover) == content {
     if cover.func() == image {
       set image(

--- a/src/components/cover.typ
+++ b/src/components/cover.typ
@@ -75,7 +75,15 @@
     ]
   }
   else if type(cover) == function {
-      cover(title, subtitle, date, authors, volume, cfg)
+      cover((
+        title: title,
+        subtitle: subtitle,
+        date: date,
+        authors: authors,
+        volume: volume,
+        ),
+        cfg
+      )
   }
 
   else if type(cover) == content {

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -492,7 +492,8 @@ These are all the options and its defaults used by _min-book_:
     is not set, it's also possible to set a custom cover image or create one
     using Typst code — the default automatic cover (see
     `/src/components/cover.typ`) can be a good start as a base to create a
-    custom version.
+    custom version. Cover can be a function, in which case it will be invoked with
+    the `title`, `subtitle`, `date`, `authors`, `volume` and `cfg` of the book.
     **/
     new(cover, title, subtitle, date, authors, volume, cfg)
     pagebreak(to: break-to)


### PR DESCRIPTION
This makes it unnecessary to duplicate the metadata / cfg such as author, title etc when using a custom cover.